### PR TITLE
Merge interupt handler refactoring from upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ rust:
   - nightly-2015-12-14
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:terry.guo/gcc-arm-embedded -y; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq gcc-arm-none-eabi; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq gcc-arm-embedded; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap px4/px4; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc-arm-none-eabi-49; fi

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ $ multirust override nightly-2015-12-14
 
 #### `arm-none-eabi` toolchain
 
+We are currently using arm-none-eabi-gcc 5.4. Using pre-5.0 versions may
+run into problems with missing intrinsics (e.g., ```__aeabi_memclr```). 
+
 On Mac OS X, you can get the arm-none-eabi toolchain via port:
 
 ```bash
@@ -49,14 +52,17 @@ or via homebrew:
 ```bash
 $ brew tap PX4/homebrew-px4
 $ brew update
-$ brew install gcc-arm-none-eabi-49
+$ brew install gcc-arm-none-eabi-54
 ```
 
-On Linux it is available through many distribution managers:
+On Linux we recommend getting packages from Launchpad
+
+https://launchpad.net/gcc-arm-embedded/+download
+
+E.g.:
 
 ```bash
-$ pacman -S arm-none-eabi-gcc
-$ apt-get install gcc-arm-none-eabi
+$ curl https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q2-update/+download/gcc-arm-none-eabi-5_4-2016q2-20160622-linux.tar.bz2
 ```
 
 For Windows and other operating systems, download site is

--- a/src/arch/cortex-m0/ctx_switch.S
+++ b/src/arch/cortex-m0/ctx_switch.S
@@ -27,29 +27,66 @@ EXC_RETURN_PSP:
   .word 0xFFFFFFFD
 
 .thumb_func
-/* r0 is top of user stack, r1 is heap base */
+/* r0 is top of user stack, r1 Process GOT */
 switch_to_user:
-  /* Load bottom of stack into Process Stack Pointer */
-  msr psp, r0
+    /* Cortex-M0 can only push registers R0-R7 directly, so move R8-R11 to R0-R3.
+     * This is equivalent to the 32-bit "push {r4-r11}" instruction. */
+    push {r4-r7}
+    mov r4,  r8
+    mov r5,  r9
+    mov r6, r10
+    mov r7, r11
+    push {r4-r7}
 
-  /* Cortex-M0 can only push registers R0-R7 directly, so move R8-R11 to R0-R3.
-   * This is equivalent to the 32-bit "push {r4-r11}" instruction. */
-  push {r4-r7}
-  mov r4,  r8
-  mov r5,  r9
-  mov r6, r10
-  mov r7, r11
-  push {r4-r7}
+    /* Load non-hardware-stacked registers from Process stack */
 
-  mov r9, r1
-  svc 0xff
+    subs r0, #32 // We actually store r4-r11 below the process stack
+    ldmia r0!, {r4-r7}
+    mov r11, r7
+    mov r10, r6
+    mov r9,  r5
+    mov r8,  r4
+    ldmia r0!, {r4-r7}
 
-  /* These instructions are equivalent to the 32-bit "pop {r4-r11}" */
-  pop {r4-r7}
-  mov  r8, r4
-  mov  r9, r5
-  mov r10, r6
-  mov r11, r7
-  pop {r4-r7}
+    /* Load bottom of stack into Process Stack Pointer */
+    msr psp, r0
 
-  bx lr
+    /* Set PIC base pointer to the Process GOT */
+    mov r9, r1
+
+    /* SWITCH */
+    svc 0xff /* It doesn't matter which SVC number we use here */
+
+    /* Push non-hardware-stacked registers onto Process stack.  r0 points to user
+     * stack (see to_kernel). We store the registers passed the stack to make it
+     * easier to address hardware-stacked registers in the rest of the kernel.
+     * This is fine since we just account for that above.
+     */
+
+    subs r0, #32 // We actually store r4-r11 below the process stack
+    str r4, [r0, #16]
+    str r5, [r0, #20]
+    str r6, [r0, #24]
+    str r7, [r0, #28]
+
+    mov  r4, r8
+    mov  r5, r9
+    mov  r6, r10
+    mov  r7, r11
+
+    str r4, [r0, #0]
+    str r5, [r0, #4]
+    str r6, [r0, #8]
+    str r7, [r0, #12]
+    adds r0, #32 // We actually store r4-r11 below the process stack
+
+    /* These instructions are equivalent to the 32-bit "pop {r4-r11}" */
+    pop {r4-r7}
+    mov  r8, r4
+    mov  r9, r5
+    mov r10, r6
+    mov r11, r7
+    pop {r4-r7}
+
+    bx lr
+

--- a/src/arch/cortex-m0/syscalls.S
+++ b/src/arch/cortex-m0/syscalls.S
@@ -12,20 +12,15 @@
 .global \NAME
 .thumb_func
 \NAME :
-  push {r4-r7}
-  mov r4,  r8
-  mov r5,  r9
-  mov r6, r10
-  mov r7, r11
-  push {r4-r7}
+.ifc \NAME,__wait
+  push {lr}
+.endif
   svc \NUM
-  pop {r4-r7}
-  mov  r8, r4
-  mov  r9, r5
-  mov r10, r6
-  mov r11, r7
-  pop {r4-r7}
+.ifc \NAME,__wait
+  pop {pc}
+.else
   bx lr
+.endif
 .endm
 
 SYSCALL __wait, 0

--- a/src/arch/cortex-m3/ctx_switch.S
+++ b/src/arch/cortex-m3/ctx_switch.S
@@ -6,6 +6,9 @@
 /* Exported functions */
 .global SVC_Handler
 .globl switch_to_user
+.globl generic_isr
+
+.extern INTERRUPT_TABLE
 
 .thumb_func
 SVC_Handler:
@@ -22,14 +25,49 @@ to_kernel:
   bx lr
 
 .thumb_func
-/* r0 is top of user stack, r1 is heap base */
+/* r0 is top of user stack, r1 Process GOT */
 switch_to_user:
+    push {r4-r11}
+
+    /* Load non-hardware-stacked registers from Process stack */
+    sub r0, #32
+    ldmia r0!, {r4-r11}
     /* Load bottom of stack into Process Stack Pointer */
     msr psp, r0
 
-    push {r4-r11}
+    /* Set PIC base pointer to the Process GOT */
     mov r9, r1
-    svc 0xff
+
+    /* SWITCH */
+    svc 0xff /* It doesn't matter which SVC number we use here */
+
+    /* Push non-hardware-stacked registers onto Process stack */
+    /* r0 points to user stack (see to_kernel) */
+    stmdb r0, {r4-r11}
+
     pop {r4-r11}
+    bx lr
+
+.thumb_func
+/* All ISRs are caught by this handler which indirects to a custom handler by
+ * indexing into `INTERRUPT_TABLE` based on the ISR number. */
+generic_isr:
+    /* Find the ISR number by looking at the low byte of the IPSR registers */
+    mrs r0, IPSR
+    and r0, #0xff
+    /* ISRs start at 16, so substract 16 to get zero-indexed */
+    sub r0, #16
+
+    /* INTERRUPT_TABLE contains function pointers, which are word sized, so
+     * multiply by 4 (the word size) */
+    lsl r0, r0, #2
+
+    ldr r1, =INTERRUPT_TABLE
+    ldr r0, [r1, r0]
+
+    push {lr}
+    blx r0
+    pop {lr}
+
     bx lr
 

--- a/src/arch/cortex-m3/syscalls.S
+++ b/src/arch/cortex-m3/syscalls.S
@@ -13,36 +13,27 @@
 
 .thumb_func
 __wait:
-    push {r4-r11,lr}
+    push {lr}
     svc 0
-    pop {r4-r11,lr}
-    bx lr
+    pop {pc}
 
 .thumb_func
 __allow:
-    push {r4-r11}
     svc 3
-    pop {r4-r11}
     bx lr
 
 .thumb_func
 __subscribe:
-    push {r4-r11}
     svc 1
-    pop {r4-r11}
     bx lr
 
 .thumb_func
 __command:
-    push {r4-r11}
     svc 2
-    pop {r4-r11}
     bx lr
 
 .thumb_func
 __memop:
-    push {r4-r11}
     svc 4
-    pop {r4-r11}
     bx lr
 

--- a/src/arch/cortex-m4/ctx_switch.S
+++ b/src/arch/cortex-m4/ctx_switch.S
@@ -6,6 +6,9 @@
 /* Exported functions */
 .global SVC_Handler
 .globl switch_to_user
+.globl generic_isr
+
+.extern INTERRUPT_TABLE
 
 .thumb_func
 SVC_Handler:
@@ -22,14 +25,49 @@ to_kernel:
   bx lr
 
 .thumb_func
-/* r0 is top of user stack, r1 is heap base */
+/* r0 is top of user stack, r1 Process GOT */
 switch_to_user:
+    push {r4-r11}
+
+    /* Load non-hardware-stacked registers from Process stack */
+    sub r0, #32
+    ldmia r0!, {r4-r11}
     /* Load bottom of stack into Process Stack Pointer */
     msr psp, r0
 
-    push {r4-r11}
+    /* Set PIC base pointer to the Process GOT */
     mov r9, r1
-    svc 0xff
+
+    /* SWITCH */
+    svc 0xff /* It doesn't matter which SVC number we use here */
+
+    /* Push non-hardware-stacked registers onto Process stack */
+    /* r0 points to user stack (see to_kernel) */
+    stmdb r0, {r4-r11}
+
     pop {r4-r11}
+    bx lr
+
+.thumb_func
+/* All ISRs are caught by this handler which indirects to a custom handler by
+ * indexing into `INTERRUPT_TABLE` based on the ISR number. */
+generic_isr:
+    /* Find the ISR number by looking at the low byte of the IPSR registers */
+    mrs r0, IPSR
+    and r0, #0xff
+    /* ISRs start at 16, so substract 16 to get zero-indexed */
+    sub r0, #16
+
+    /* INTERRUPT_TABLE contains function pointers, which are word sized, so
+     * multiply by 4 (the word size) */
+    lsl r0, r0, #2
+
+    ldr r1, =INTERRUPT_TABLE
+    ldr r0, [r1, r0]
+
+    push {lr}
+    blx r0
+    pop {lr}
+
     bx lr
 

--- a/src/arch/cortex-m4/syscalls.S
+++ b/src/arch/cortex-m4/syscalls.S
@@ -13,36 +13,27 @@
 
 .thumb_func
 __wait:
-    push {r4-r11,lr}
+    push {lr}
     svc 0
-    pop {r4-r11,lr}
-    bx lr
+    pop {pc}
 
 .thumb_func
 __allow:
-    push {r4-r11}
     svc 3
-    pop {r4-r11}
     bx lr
 
 .thumb_func
 __subscribe:
-    push {r4-r11}
     svc 1
-    pop {r4-r11}
     bx lr
 
 .thumb_func
 __command:
-    push {r4-r11}
     svc 2
-    pop {r4-r11}
     bx lr
 
 .thumb_func
 __memop:
-    push {r4-r11}
     svc 4
-    pop {r4-r11}
     bx lr
 

--- a/src/chips/hotel/lib.rs
+++ b/src/chips/hotel/lib.rs
@@ -39,6 +39,8 @@ extern {
 
     fn SVC_Handler();
 
+    fn generic_isr();
+
     static mut _ero : u32;
     static mut _sdata : u32;
     static mut _edata : u32;
@@ -66,6 +68,12 @@ pub static ISR_VECTOR: [Option<unsafe extern fn()>; 16] = [
     /* PendSV */        Option::Some(unhandled_interrupt),
     /* SysTick */       Option::Some(unhandled_interrupt),
 ];
+
+#[link_section=".vectors"]
+pub static IRQS: [unsafe extern fn(); 0] = [generic_isr; 0];
+
+#[no_mangle]
+pub static INTERRUPT_TABLE: [Option<unsafe extern fn()>; 0] = [];
 
 unsafe extern "C" fn reset_handler() {
     // Relocate data segment.

--- a/src/chips/sam4l/adc.rs
+++ b/src/chips/sam4l/adc.rs
@@ -35,7 +35,6 @@ use core::intrinsics;
 use nvic;
 use hil::adc::{Request, AdcInternal};
 use pm::{self, Clock, PBAClock};
-use chip;
 use scif;
 
 
@@ -183,12 +182,5 @@ impl AdcInternal for Adc {
     }
 }
 
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn ADCIFE_Handler() {
-    use common::Queue;
-    nvic::disable(nvic::NvicIdx::ADCIFE);
-    chip::INTERRUPT_QUEUE.as_mut().map(|q| {
-        q.enqueue(nvic::NvicIdx::ADCIFE)
-    });
-}
+interrupt_handler!(adcife_handler, ADCIFE);
+

--- a/src/chips/sam4l/ast.rs
+++ b/src/chips/sam4l/ast.rs
@@ -10,7 +10,6 @@ use core::intrinsics;
 use nvic;
 use hil::alarm::{Alarm, AlarmClient, Freq16Khz};
 use hil::Controller;
-use chip;
 use pm::{self, PBDClock};
 
 #[repr(C, packed)]
@@ -67,8 +66,6 @@ impl Controller for Ast {
         self.set_prescalar(0); // 32Khz / (2^(0 + 1)) = 16Khz
         self.enable_alarm_wake();
         self.clear_alarm();
-
-        self.enable();
     }
 }
 
@@ -138,6 +135,13 @@ impl Ast {
         unsafe {
             let cr = intrinsics::volatile_load(&(*self.regs).cr) | 1;
             intrinsics::volatile_store(&mut (*self.regs).cr, cr);
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        while self.busy() {}
+        unsafe {
+            intrinsics::volatile_load(&(*self.regs).cr) & 1 == 1
         }
     }
 
@@ -240,6 +244,7 @@ impl Alarm for Ast {
     type Frequency = Freq16Khz;
 
     fn now(&self) -> u32 {
+        while self.busy() {}
         unsafe {
             intrinsics::volatile_load(&(*self.regs).cv)
         }
@@ -247,6 +252,10 @@ impl Alarm for Ast {
 
     fn disable_alarm(&self) {
         self.disable_alarm_irq();
+    }
+
+    fn is_armed(&self) -> bool {
+        self.is_enabled()
     }
 
     fn set_alarm(&self, tics: u32) {
@@ -261,18 +270,12 @@ impl Alarm for Ast {
     }
 
     fn get_alarm(&self) -> u32 {
+        while self.busy() {}
         unsafe {
             intrinsics::volatile_load(&(*self.regs).ar0)
         }
     }
 }
 
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn AST_ALARM_Handler() {
-    use common::Queue;
-
-    nvic::disable(nvic::NvicIdx::ASTALARM);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::ASTALARM);
-}
+interrupt_handler!(ast_alarm_handler, ASTALARM);
 

--- a/src/chips/sam4l/dma.rs
+++ b/src/chips/sam4l/dma.rs
@@ -265,87 +265,33 @@ impl DMAChannel {
     }
 }
 
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn PDCA_0_Handler() {
-    use common::Queue;
-    use nvic;
-    use chip;
-
-    let registers : &mut DMARegisters =
-        mem::transmute(DMAChannels[0].registers);
-    volatile_store(&mut registers.interrupt_disable, 0xffffffff);
-    nvic::disable(nvic::NvicIdx::PDCA0);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::PDCA0);
+macro_rules! pdca_handler {
+    ($name: ident, $nvic: ident, $num: expr) => {
+        interrupt_handler!(
+            $name,
+            $nvic,
+            {
+                let registers : &mut DMARegisters =
+                    mem::transmute(DMAChannels[$num].registers);
+                volatile_store(&mut registers.interrupt_disable, 0xffffffff);
+            });
+    }
 }
 
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn PDCA_1_Handler() {
-    use common::Queue;
-    use nvic;
-    use chip;
-
-    let registers : &mut DMARegisters =
-        mem::transmute(DMAChannels[1].registers);
-    volatile_store(&mut registers.interrupt_disable, 0xffffffff);
-    nvic::disable(nvic::NvicIdx::PDCA1);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::PDCA1);
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn PDCA_2_Handler() {
-    use common::Queue;
-    use nvic;
-    use chip;
-
-    let registers : &mut DMARegisters =
-        mem::transmute(DMAChannels[2].registers);
-    volatile_store(&mut registers.interrupt_disable, 0xffffffff);
-    nvic::disable(nvic::NvicIdx::PDCA2);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::PDCA2);
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn PDCA_3_Handler() {
-    use common::Queue;
-    use nvic;
-    use chip;
-
-    let registers : &mut DMARegisters =
-        mem::transmute(DMAChannels[3].registers);
-    volatile_store(&mut registers.interrupt_disable, 0xffffffff);
-    nvic::disable(nvic::NvicIdx::PDCA3);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::PDCA3);
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn PDCA_4_Handler() {
-    use common::Queue;
-    use nvic;
-    use chip;
-
-    let registers : &mut DMARegisters =
-        mem::transmute(DMAChannels[4].registers);
-    volatile_store(&mut registers.interrupt_disable, 0xffffffff);
-    nvic::disable(nvic::NvicIdx::PDCA4);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::PDCA4);
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn PDCA_5_Handler() {
-    use common::Queue;
-    use nvic;
-    use chip;
-
-    let registers : &mut DMARegisters =
-        mem::transmute(DMAChannels[5].registers);
-    volatile_store(&mut registers.interrupt_disable, 0xffffffff);
-    nvic::disable(nvic::NvicIdx::PDCA5);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::PDCA5);
-}
+pdca_handler!(pdca0_handler,  PDCA0,  0);
+pdca_handler!(pdca1_handler,  PDCA1,  1);
+pdca_handler!(pdca2_handler,  PDCA2,  2);
+pdca_handler!(pdca3_handler,  PDCA3,  3);
+pdca_handler!(pdca4_handler,  PDCA4,  4);
+pdca_handler!(pdca5_handler,  PDCA5,  5);
+pdca_handler!(pdca6_handler,  PDCA6,  6);
+pdca_handler!(pdca7_handler,  PDCA7,  7);
+pdca_handler!(pdca8_handler,  PDCA8,  8);
+pdca_handler!(pdca9_handler,  PDCA9,  9);
+pdca_handler!(pdca10_handler, PDCA10, 10);
+pdca_handler!(pdca11_handler, PDCA11, 11);
+pdca_handler!(pdca12_handler, PDCA12, 12);
+pdca_handler!(pdca13_handler, PDCA13, 13);
+pdca_handler!(pdca14_handler, PDCA14, 14);
+pdca_handler!(pdca15_handler, PDCA15, 15);
 

--- a/src/chips/sam4l/gpio.rs
+++ b/src/chips/sam4l/gpio.rs
@@ -4,7 +4,6 @@ use core::mem;
 use core::ops::{Index, IndexMut};
 use hil;
 use nvic;
-use chip;
 use nvic::NvicIdx::*;
 
 use common::take_cell::TakeCell;
@@ -475,111 +474,28 @@ impl hil::gpio::GPIOPin for GPIOPin {
     }
 }
 
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn GPIO_0_Handler() {
-    use common::Queue;
+macro_rules! gpio_handler {
+    ($num: ident) => {
+        interrupt_handler!(concat_idents!(GPIO_, $num, _Handler), {
+            use common::Queue;
 
-    nvic::disable(nvic::NvicIdx::GPIO0);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::GPIO0);
+            let nvic = concat_idents!(nvic::NvicIdx::GPIO, $num);
+            nvic::disable(nvic);
+            chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic);
+        })
+    }
 }
 
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn GPIO_1_Handler() {
-    use common::Queue;
-
-    nvic::disable(nvic::NvicIdx::GPIO1);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::GPIO1);
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn GPIO_2_Handler() {
-    use common::Queue;
-
-    nvic::disable(nvic::NvicIdx::GPIO2);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::GPIO2);
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn GPIO_3_Handler() {
-    use common::Queue;
-
-    nvic::disable(nvic::NvicIdx::GPIO3);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::GPIO3);
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn GPIO_4_Handler() {
-    use common::Queue;
-
-    nvic::disable(nvic::NvicIdx::GPIO4);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::GPIO4);
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn GPIO_5_Handler() {
-    use common::Queue;
-
-    nvic::disable(nvic::NvicIdx::GPIO5);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::GPIO5);
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn GPIO_6_Handler() {
-    use common::Queue;
-
-    nvic::disable(nvic::NvicIdx::GPIO6);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::GPIO6);
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn GPIO_7_Handler() {
-    use common::Queue;
-
-    nvic::disable(nvic::NvicIdx::GPIO7);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::GPIO7);
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn GPIO_8_Handler() {
-    use common::Queue;
-
-    nvic::disable(nvic::NvicIdx::GPIO8);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::GPIO8);
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn GPIO_9_Handler() {
-    use common::Queue;
-
-    nvic::disable(nvic::NvicIdx::GPIO9);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::GPIO9);
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn GPIO_10_Handler() {
-    use common::Queue;
-
-    nvic::disable(nvic::NvicIdx::GPIO10);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::GPIO10);
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn GPIO_11_Handler() {
-    use common::Queue;
-
-    nvic::disable(nvic::NvicIdx::GPIO11);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::GPIO11);
-}
+interrupt_handler!(gpio0_handler,  GPIO0);
+interrupt_handler!(gpio1_handler,  GPIO1);
+interrupt_handler!(gpio2_handler,  GPIO2);
+interrupt_handler!(gpio3_handler,  GPIO3);
+interrupt_handler!(gpio4_handler,  GPIO4);
+interrupt_handler!(gpio5_handler,  GPIO5);
+interrupt_handler!(gpio6_handler,  GPIO6);
+interrupt_handler!(gpio7_handler,  GPIO7);
+interrupt_handler!(gpio8_handler,  GPIO8);
+interrupt_handler!(gpio9_handler,  GPIO9);
+interrupt_handler!(gpio10_handler, GPIO10);
+interrupt_handler!(gpio11_handler, GPIO11);
 

--- a/src/chips/sam4l/helpers.rs
+++ b/src/chips/sam4l/helpers.rs
@@ -27,3 +27,24 @@ pub fn volatile_bitwise_and<T: BitAnd<Output = T>>(item: &mut T, val: T) {
     volatile_transform(item, |t| { t & val });
 }
 
+#[macro_export]
+macro_rules! interrupt_handler {
+    ($name: ident, $nvic: ident $(, $body: expr)*) => {
+        #[no_mangle]
+        #[allow(non_snake_case)]
+        #[allow(unused_imports)]
+        pub unsafe extern fn $name() {
+            use common::Queue;
+            use chip;
+
+            $({
+                $body
+            })*
+
+            let nvic = nvic::NvicIdx::$nvic;
+            nvic::disable(nvic);
+            chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic);
+        }
+    }
+}
+

--- a/src/chips/sam4l/i2c.rs
+++ b/src/chips/sam4l/i2c.rs
@@ -362,12 +362,8 @@ impl hil::i2c::I2CController for I2CDevice {
     }
 }
 
-pub unsafe extern "C" fn twim2_interrupt() {
-    use chip;
-    use common::Queue;
-
-    let dev = &I2C2;
-    dev.disable_interrupts();
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(dev.nvic);
-}
+interrupt_handler!(twim0_handler, TWIM0, { I2C0.disable_interrupts() });
+interrupt_handler!(twim1_handler, TWIM1, { I2C1.disable_interrupts() });
+interrupt_handler!(twim2_handler, TWIM2, { I2C2.disable_interrupts() });
+interrupt_handler!(twim3_handler, TWIM3, { I2C3.disable_interrupts() });
 

--- a/src/chips/sam4l/usart.rs
+++ b/src/chips/sam4l/usart.rs
@@ -5,7 +5,6 @@ use hil::uart::{Parity, Mode};
 use dma::{DMAChannel, DMAClient, DMAPeripheral};
 use nvic;
 use pm::{self, Clock, PBAClock};
-use chip;
 
 #[repr(C, packed)]
 struct Registers {
@@ -267,21 +266,7 @@ impl uart::UART for USART {
 
 }
 
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn USART2_Handler() {
-    use common::Queue;
-
-    nvic::disable(nvic::NvicIdx::USART2);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::USART2);
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern fn USART3_Handler() {
-    use common::Queue;
-
-    nvic::disable(nvic::NvicIdx::USART3);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::USART3);
-}
-
+interrupt_handler!(usart0_handler, USART0);
+interrupt_handler!(usart1_handler, USART1);
+interrupt_handler!(usart2_handler, USART2);
+interrupt_handler!(usart3_handler, USART3);

--- a/src/common/lib.rs
+++ b/src/common/lib.rs
@@ -19,3 +19,4 @@ pub use queue::Queue;
 pub use ring_buffer::RingBuffer;
 pub use volatile_cell::VolatileCell;
 pub use list::{List, ListLink, ListNode};
+

--- a/src/drivers/isl29035.rs
+++ b/src/drivers/isl29035.rs
@@ -105,6 +105,7 @@ impl<'a> I2CClient for Isl29035<'a> {
                 self.state.set(State::Disabling(lux));
             },
             State::Disabling(lux) => {
+                self.i2c.disable();
                 self.state.set(State::Disabled);
                 self.buffer.replace(buffer);
                 self.callback.get().map(|mut cb| cb.schedule(lux, 0, 0));

--- a/src/drivers/timer.rs
+++ b/src/drivers/timer.rs
@@ -2,78 +2,7 @@ use core::cell::Cell;
 use process::{AppId, Container, Callback};
 use hil::Driver;
 use hil::alarm::{Alarm, AlarmClient, Frequency};
-use hil::timer::{Timer, TimerClient};
-
-#[derive(Copy, Clone)]
-enum Schedule {
-    Oneshot,
-    Repeating { interval: u32 }
-}
-
-pub struct AlarmToTimer<'a, Alrm: Alarm + 'a> {
-    schedule: Cell<Schedule>,
-    alarm: &'a Alrm,
-    client: Cell<Option<&'a TimerClient>>
-}
-
-impl<'a, Alrm: Alarm> AlarmToTimer<'a, Alrm> {
-    pub const fn new(alarm: &'a Alrm) -> AlarmToTimer<'a, Alrm> {
-        AlarmToTimer {
-            schedule: Cell::new(Schedule::Oneshot),
-            alarm: alarm,
-            client: Cell::new(None)
-        }
-    }
-
-    pub fn set_client(&self, client: &'a TimerClient) {
-        self.client.set(Some(client));
-    }
-}
-
-impl<'a, Alrm: Alarm> Timer for AlarmToTimer<'a, Alrm> {
-    fn now(&self) -> u32 {
-        self.alarm.now()
-    }
-
-    fn oneshot(&self, interval_ms: u32) {
-        let interval = interval_ms * <Alrm::Frequency>::frequency() / 1000;
-
-        self.schedule.set(Schedule::Oneshot);
-
-        let when = interval.wrapping_add(self.alarm.now());
-        self.alarm.set_alarm(when);
-    }
-
-    fn repeat(&self, interval_ms: u32) {
-        let interval = interval_ms * <Alrm::Frequency>::frequency() / 1000;
-
-        self.schedule.set(Schedule::Repeating {interval: interval});
-
-        let when = interval.wrapping_add(self.alarm.now());
-        self.alarm.set_alarm(when);
-    }
-
-    fn stop(&self) {
-        self.alarm.disable_alarm();
-    }
-}
-
-impl<'a, Alrm: Alarm> AlarmClient for AlarmToTimer<'a, Alrm> {
-    fn fired(&self) {
-        let now = self.now();
-
-        match self.schedule.get() {
-            Schedule::Oneshot => self.alarm.disable_alarm(),
-
-            Schedule::Repeating { interval } => {
-                let when = interval.wrapping_add(now);
-                self.alarm.set_alarm(when);
-            }
-        }
-
-        self.client.get().map(|client| client.fired(now) );
-    }
-}
+use hil::timer::{Timer};
 
 #[derive(Copy, Clone)]
 pub struct TimerData {
@@ -89,22 +18,45 @@ impl Default for TimerData {
     }
 }
 
-pub struct TimerDriver<'a, T: Timer + 'a> {
-    timer: &'a T,
+pub struct TimerDriver<'a, A: Alarm + 'a> {
+    alarm: &'a A,
+    num_armed: Cell<usize>,
     app_timer: Container<TimerData>
 }
 
-impl<'a, T: Timer> TimerDriver<'a, T> {
-    pub const fn new(timer: &'a T, container: Container<TimerData>)
-            -> TimerDriver<'a, T> {
+impl<'a, A: Alarm + 'a> TimerDriver<'a, A> {
+    pub const fn new(alarm: &'a A, container: Container<TimerData>)
+            -> TimerDriver<'a, A> {
         TimerDriver {
-            timer: timer,
+            alarm: alarm,
+            num_armed: Cell::new(0),
             app_timer: container
+        }
+    }
+
+    fn reset_active_timer(&self) {
+        let now = self.alarm.now();
+        let mut next_alarm = u32::max_value();
+        let mut next_dist = u32::max_value();
+        for timer in self.app_timer.iter() {
+            timer.enter(|timer, _| {
+                if timer.interval > 0 {
+                    let t_alarm = timer.t0.wrapping_add(timer.interval);
+                    let t_dist = t_alarm.wrapping_sub(now);
+                    if next_dist > t_dist {
+                        next_alarm = t_alarm;
+                        next_dist = t_dist;
+                    }
+                }
+            });
+        }
+        if next_alarm != u32::max_value() {
+            self.alarm.set_alarm(next_alarm);
         }
     }
 }
 
-impl<'a, T: Timer> Driver for TimerDriver<'a, T> {
+impl<'a, A: Alarm> Driver for TimerDriver<'a, A> {
     fn subscribe(&self, _: usize, callback: Callback) -> isize {
         self.app_timer.enter(callback.app_id(), |td, _allocator| {
             td.callback = Some(callback);
@@ -114,45 +66,102 @@ impl<'a, T: Timer> Driver for TimerDriver<'a, T> {
 
     fn command(&self, cmd_type: usize, interval: usize, caller_id: AppId)
             -> isize {
-        let interval = interval as u32;
-        self.app_timer.enter(caller_id, |td, _allocator| {
+        // First, convert from milliseconds to native clock frequency
+        let interval = (interval as u32) * <A::Frequency>::frequency() / 1000;
+
+        // Returns the error code to return to the user (0 for success, negative
+        // otherwise) and whether we need to reset which is the next active
+        // alarm. We only _don't_ reset if we're disabling the underlying alarm
+        // anyway, if the underlying alarm is currently disabled and we're
+        // enabling the first alarm, or on an error (i.e. no change to the
+        // alarms).
+        let (err_code, reset) = self.app_timer.enter(caller_id, |td, _alloc| {
             match cmd_type {
-                0 /* Oneshot */ => {
-                    td.t0 = self.timer.now();
-                    td.interval = interval;
-                    td.repeating = false;
-                    self.timer.oneshot(interval);
-                    0
-                },
-                1 /* Repeating */ => {
-                    td.t0 = self.timer.now();
-                    td.interval = interval;
-                    td.repeating = true;
-                    self.timer.repeat(interval);
-                    0
-                },
                 2 /* Stop */ => {
-                    td.interval = 0;
-                    td.t0 = 0;
-                    self.timer.stop();
-                    0
+                    if td.interval > 0 {
+                        td.interval = 0;
+                        td.t0 = 0;
+                        let num_armed = self.num_armed.get();
+                        self.num_armed.set(num_armed - 1);
+                        if num_armed == 1 {
+                            self.alarm.disable_alarm();
+                            (0, false)
+                        } else {
+                            (0, true)
+                        }
+                    } else {
+                        (-2, false)
+                    }
                 },
-                _ => -1
+                /* 0 for Oneshot, 1 for Repeat */
+                cmd_type if cmd_type <= 1 => {
+                    if interval == 0 {
+                        return (-2, false);
+                    }
+
+                    // if previously unarmed, but now will become armed
+                    if td.interval == 0 {
+                        self.num_armed.set(self.num_armed.get() + 1);
+                    }
+
+                    td.t0 = self.alarm.now();
+                    td.interval = interval;
+
+                    // Repeat if cmd_type was 1
+                    td.repeating = cmd_type == 1;
+                    if self.alarm.is_armed() {
+                        (0, true)
+                    } else {
+                        self.alarm.set_alarm(td.t0.wrapping_add(td.interval));
+                        (0, false)
+                    }
+                },
+                _ => (-1, false)
             }
-        }).unwrap_or(-2)
+        }).unwrap_or((-3, false));
+        if reset {
+            self.reset_active_timer();
+        }
+        err_code
     }
 }
 
-impl<'a, T: Timer> TimerClient for TimerDriver<'a, T> {
-    fn fired(&self, now: u32) {
+impl<'a, A: Alarm> AlarmClient for TimerDriver<'a, A> {
+    fn fired(&self) {
+        let now = self.alarm.now();
+
         self.app_timer.each(|timer| {
             let elapsed = now.wrapping_sub(timer.t0);
-            if elapsed >= timer.interval {
+
+            // timer.interval == 0 means the timer is inactive
+            if timer.interval > 0 &&
+                    // Becuse of the calculations done for timer.interval when
+                    // setting the timer, we might fire earlier than expected
+                    // by some jitter.
+                    elapsed >= timer.interval {
+
+                if timer.repeating {
+                    // Repeating timer, reset the reference time to now
+                    timer.t0 = now;
+                } else {
+                    // Deactivate timer
+                    timer.interval = 0;
+                    self.num_armed.set(self.num_armed.get() - 1);
+                }
+
                 timer.callback.map(|mut cb| {
                     cb.schedule(now as usize, 0, 0);
                 });
             }
         });
+
+        // If there are armed timers left, reset the underlying timer to the
+        // nearest interval. Otherwise, disable the underlying timer.
+        if self.num_armed.get() > 0 {
+            self.reset_active_timer();
+        } else {
+            self.alarm.disable_alarm();
+        }
     }
 }
 

--- a/src/drivers/virtual_i2c.rs
+++ b/src/drivers/virtual_i2c.rs
@@ -28,9 +28,10 @@ impl<'a> MuxI2C<'a> {
             inflight: TakeCell::empty()
         }
     }
+
     fn enable(&self) {
         let enabled = self.enabled.get();
-        self.enabled.set(enabled);
+        self.enabled.set(enabled + 1);
         if enabled == 0 {
             self.i2c.enable();
         }
@@ -123,12 +124,14 @@ impl<'a> ListNode<'a, I2CDevice<'a>> for I2CDevice<'a> {
 impl<'a> i2c::I2CDevice for I2CDevice<'a> {
     fn enable(&self) {
         if !self.enabled.get() {
+            self.enabled.set(true);
             self.mux.enable();
         }
     }
 
     fn disable(&self) {
         if self.enabled.get() {
+            self.enabled.set(false);
             self.mux.disable();
         }
     }

--- a/src/hil/alarm.rs
+++ b/src/hil/alarm.rs
@@ -48,6 +48,9 @@ pub trait Alarm {
     /// Disables the alarm.
     fn disable_alarm(&self);
 
+    /// Returns true if the alarm is armed
+    fn is_armed(&self) -> bool;
+
     /// Returns the value set in [`set_alarm`](#tymethod.set_alarm)
     fn get_alarm(&self) -> u32;
 }

--- a/src/platform/storm/lib.rs
+++ b/src/platform/storm/lib.rs
@@ -13,7 +13,6 @@ extern crate process;
 use hil::Controller;
 use hil::spi_master::SpiMaster;
 use hil::gpio::GPIOPin;
-use drivers::timer::AlarmToTimer;
 use drivers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use drivers::virtual_i2c::{MuxI2C, I2CDevice};
 
@@ -34,8 +33,8 @@ pub struct Firestorm {
     chip: sam4l::chip::Sam4l,
     console: &'static drivers::console::Console<'static, sam4l::usart::USART>,
     gpio: &'static drivers::gpio::GPIO<'static, sam4l::gpio::GPIOPin>,
-    timer: &'static drivers::timer::TimerDriver<'static, AlarmToTimer<'static,
-                                VirtualMuxAlarm<'static, sam4l::ast::Ast>>>,
+    timer: &'static drivers::timer::TimerDriver<'static,
+                VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
     tmp006: &'static drivers::tmp006::TMP006<'static>,
     isl29035: &'static drivers::isl29035::Isl29035<'static>,
     spi: &'static drivers::spi::Spi<'static, sam4l::spi::Spi>,
@@ -320,15 +319,11 @@ pub unsafe fn init<'a>() -> &'a mut Firestorm {
 
     static_init!(virtual_alarm1 : VirtualMuxAlarm<'static, sam4l::ast::Ast> =
                     VirtualMuxAlarm::new(mux_alarm));
-    static_init!(vtimer1 : AlarmToTimer<'static,
+    static_init!(timer : drivers::timer::TimerDriver<'static,
                                 VirtualMuxAlarm<'static, sam4l::ast::Ast>> =
-                            AlarmToTimer::new(virtual_alarm1));
-    virtual_alarm1.set_client(vtimer1);
-    static_init!(timer : drivers::timer::TimerDriver<AlarmToTimer<'static,
-                                VirtualMuxAlarm<'static, sam4l::ast::Ast>>> =
-                            drivers::timer::TimerDriver::new(vtimer1,
+                            drivers::timer::TimerDriver::new(virtual_alarm1,
                                             process::Container::create()));
-    vtimer1.set_client(timer);
+    virtual_alarm1.set_client(timer);
 
     // Initialize and enable SPI HAL
     static_init!(spi: drivers::spi::Spi<'static, sam4l::spi::Spi> =


### PR DESCRIPTION
Most of this PR contains commits from helena-project/tock#61. The only code specific to this port is in the very last commit bddfd0b, however, feel free to comment on the rest as well.

At a high level, these changes are in preparation for prioritizing kernel code in the scheduler. This will require storing the process's r4-r11 registers, which are not saved by the hardware, in all exception handlers, not just after an SVC.