### PR TITLE
Implement Timels driver for hotel

### DIFF
--- a/src/chips/hotel/src/chip.rs
+++ b/src/chips/hotel/src/chip.rs
@@ -1,6 +1,7 @@
 use cortexm3;
 use main::Chip;
 use gpio;
+use timels;
 use uart;
 
 pub struct Hotel {
@@ -29,6 +30,8 @@ impl Chip for Hotel {
         unsafe {
             cortexm3::nvic::next_pending().map(|nvic_num| {
                 match nvic_num {
+                    159 => timels::Timels0.handle_interrupt(),
+                    160 => timels::Timels1.handle_interrupt(),
                     174 => uart::UART0.handle_rx_interrupt(),
                     177 => uart::UART0.handle_tx_interrupt(),
                     181 => uart::UART1.handle_rx_interrupt(),

--- a/src/chips/hotel/src/gpio.rs
+++ b/src/chips/hotel/src/gpio.rs
@@ -1,4 +1,3 @@
-
 use common::take_cell::TakeCell;
 use common::volatile_cell::VolatileCell;
 use core::cell::Cell;

--- a/src/chips/hotel/src/lib.rs
+++ b/src/chips/hotel/src/lib.rs
@@ -12,6 +12,7 @@ pub mod chip;
 pub mod gpio;
 pub mod pinmux;
 pub mod pmu;
+pub mod timels;
 pub mod timeus;
 pub mod uart;
 

--- a/src/chips/hotel/src/timels.rs
+++ b/src/chips/hotel/src/timels.rs
@@ -1,0 +1,101 @@
+use core::cell::Cell;
+use common::take_cell::TakeCell;
+use common::volatile_cell::VolatileCell;
+use hil::alarm::{Alarm,AlarmClient,Frequency};
+
+const TIMELS0_BASE: *const Registers = 0x40540000 as *const Registers;
+const TIMELS1_BASE: *const Registers = 0x40540040 as *const Registers;
+
+pub static mut Timels0: Timels = Timels::new(TIMELS0_BASE);
+pub static mut Timels1: Timels = Timels::new(TIMELS1_BASE);
+
+struct Registers {
+    pub control: VolatileCell<u32>,
+    pub status: VolatileCell<u32>,
+    pub load: VolatileCell<u32>,
+    pub reload: VolatileCell<u32>,
+    pub value: VolatileCell<u32>,
+    pub step: VolatileCell<u32>,
+    pub interrupt_enable: VolatileCell<u32>,
+    pub interrupt_status: VolatileCell<u32>,
+    pub interrupt_pending: VolatileCell<u32>,
+    pub interrupt_ack: VolatileCell<u32>,
+    pub interrupt_wakeup_ack: VolatileCell<u32>,
+}
+
+pub struct Timels {
+    registers: *const Registers,
+    client: TakeCell<&'static AlarmClient>,
+    now: Cell<u32>,
+}
+
+impl Timels {
+    const fn new(regs: *const Registers) -> Timels {
+        Timels {
+            registers: regs,
+            client: TakeCell::empty(),
+            now: Cell::new(0),
+        }
+    }
+
+    pub fn set_client(&'static self, client: &'static AlarmClient) {
+        self.client.put(Some(client));
+    }
+
+    pub fn handle_interrupt(&self) {
+        let regs = unsafe { &*self.registers };
+        regs.interrupt_ack.set(1);
+        regs.interrupt_wakeup_ack.set(1);
+        regs.control.set(0);
+        self.now.set(self.now.get().wrapping_add(regs.reload.get()));
+        regs.reload.set(0);
+        self.client.map(|client| {
+            client.fired();
+        });
+    }
+}
+
+pub struct Freq256Khz;
+
+impl Frequency for Freq256Khz {
+    fn frequency() -> u32 {
+        256000
+    }
+}
+
+impl Alarm for Timels {
+    type Frequency = Freq256Khz;
+
+    fn now(&self) -> u32 {
+        let regs = unsafe { &*self.registers };
+        let cur = regs.value.get();
+        let reload = regs.reload.get();
+        let elapsed = reload - cur;
+        self.now.get().wrapping_add(elapsed)
+    }
+
+    fn set_alarm(&self, tics: u32) {
+        let distance = tics.wrapping_sub(self.now.get());
+        let regs = unsafe { &*self.registers };
+        regs.load.set(distance); 
+        regs.reload.set(distance);
+        regs.interrupt_enable.set(1);
+        regs.control.set(1);
+    }
+
+    fn disable_alarm(&self) {
+        let regs = unsafe { &*self.registers };
+        regs.control.set(0);
+    }
+
+    fn is_armed(&self) -> bool {
+        let regs = unsafe { &*self.registers };
+        regs.control.get() & 1 == 1 && regs.value.get() != 0
+    }
+
+    fn get_alarm(&self) -> u32 {
+        let regs = unsafe { &*self.registers };
+        regs.reload.get()
+    }
+}
+

--- a/src/chips/hotel/src/timels.rs
+++ b/src/chips/hotel/src/timels.rs
@@ -1,7 +1,8 @@
-use core::cell::Cell;
+
 use common::take_cell::TakeCell;
 use common::volatile_cell::VolatileCell;
-use hil::alarm::{Alarm,AlarmClient,Frequency};
+use core::cell::Cell;
+use hil::alarm::{Alarm, AlarmClient, Frequency};
 
 const TIMELS0_BASE: *const Registers = 0x40540000 as *const Registers;
 const TIMELS1_BASE: *const Registers = 0x40540040 as *const Registers;
@@ -77,7 +78,7 @@ impl Alarm for Timels {
     fn set_alarm(&self, tics: u32) {
         let distance = tics.wrapping_sub(self.now.get());
         let regs = unsafe { &*self.registers };
-        regs.load.set(distance); 
+        regs.load.set(distance);
         regs.reload.set(distance);
         regs.interrupt_enable.set(1);
         regs.control.set(1);
@@ -98,4 +99,3 @@ impl Alarm for Timels {
         regs.reload.get()
     }
 }
-

--- a/src/chips/hotel/src/timeus.rs
+++ b/src/chips/hotel/src/timeus.rs
@@ -1,4 +1,3 @@
-
 use common::volatile_cell::VolatileCell;
 use core::mem;
 

--- a/src/platform/golf/src/main.rs
+++ b/src/platform/golf/src/main.rs
@@ -56,22 +56,24 @@ unsafe fn load_processes() -> &'static mut [Option<main::process::Process<'stati
 pub struct Golf {
     console: &'static drivers::console::Console<'static, hotel::uart::UART>,
     gpio: &'static drivers::gpio::GPIO<'static, hotel::gpio::Pin>,
+    timer: &'static drivers::timer::TimerDriver<'static, hotel::timels::Timels>
 }
 
 #[no_mangle]
 pub unsafe fn reset_handler() {
     hotel::init();
 
-    let timer = {
+    let timerhs = {
         use hotel::pmu::*;
         use hotel::timeus::Timeus;
         Clock::new(PeripheralClock::Bank1(PeripheralClock1::TimeUs0Timer)).enable();
+        Clock::new(PeripheralClock::Bank1(PeripheralClock1::TimeLs0)).enable();
         let timer = Timeus::new(0);
         timer
     };
 
-    timer.start();
-    let start = timer.now();
+    timerhs.start();
+    let start = timerhs.now();
 
     {
         use hotel::pmu::*;
@@ -110,12 +112,20 @@ pub unsafe fn reset_handler() {
         pin.set_client(gpio)
     }
 
+    let timer = static_init!(
+        drivers::timer::TimerDriver<'static, hotel::timels::Timels>,
+        drivers::timer::TimerDriver::new(
+            &hotel::timels::Timels0, main::container::Container::create()),
+        12);
+    hotel::timels::Timels0.set_client(timer);
+
     let platform = static_init!(Golf, Golf {
         console: console,
-        gpio: gpio
-    }, 8);
+        gpio: gpio,
+        timer: timer,
+    }, 12);
 
-    let end = timer.now();
+    let end = timerhs.now();
 
     println!("Hello from Rust! Initialization took {} tics.",
              end.wrapping_sub(start));
@@ -134,6 +144,7 @@ impl Platform for Golf {
         match driver_num {
             0 => f(Some(self.console)),
             1 => f(Some(self.gpio)),
+            3 => f(Some(self.timer)),
             _ => f(None),
         }
     }


### PR DESCRIPTION
The timels controller is asynchronous (i.e. it keeps running during
sleep), so we use this controller for an `Alarm` to pass to the Timer
driver.