### PR TITLE
Make SHA finalize asynchronous

### DIFF
--- a/golf/src/main.rs
+++ b/golf/src/main.rs
@@ -121,9 +121,10 @@ pub unsafe fn reset_handler() {
     let digest = static_init!(
         digest::DigestDriver<'static, hotel::crypto::sha::ShaEngine>,
         digest::DigestDriver::new(
-                &mut hotel::crypto::sha::KEYMGR0_SHA,
+                &hotel::crypto::sha::KEYMGR0_SHA,
                 kernel::Container::create()),
         16);
+    hotel::crypto::sha::KEYMGR0_SHA.set_client(digest);
 
     let platform = static_init!(Golf, Golf {
         console: console,

--- a/hotel/src/chip.rs
+++ b/hotel/src/chip.rs
@@ -1,4 +1,5 @@
 use cortexm3;
+use crypto;
 use gpio;
 use kernel::Chip;
 use timels;
@@ -31,7 +32,7 @@ impl Chip for Hotel {
         unsafe {
             while let Some(nvic_num) = cortexm3::nvic::next_pending() {
                 match nvic_num {
-                    110 => (), // KEYMGR0_DSHA_INT, currently polled
+                    110 => crypto::sha::KEYMGR0_SHA.handle_interrupt(),
                     111 => (), // KEYMGR0_SHA_WFIFO_FULL
 
                     159 => timels::Timels0.handle_interrupt(),

--- a/hotel/src/crypto/sha.rs
+++ b/hotel/src/crypto/sha.rs
@@ -1,4 +1,3 @@
-use core::mem;
 use hil::digest::{DigestEngine, DigestMode, DigestError};
 use kernel::common::volatile_cell::VolatileCell;
 use super::KEYMGR0_BASE_ADDRESS;
@@ -11,7 +10,7 @@ struct Registers {
     cfg_wr_en: VolatileCell<u32>, // 0x40C
     trig: VolatileCell<u32>, // 0x410
     _padding_414: [u8; 0x440 - 0x414], // 0x414
-    input_fifo: VolatileCell<u32>, // 0x440
+    input_fifo: U32OrU8, // 0x440
     sts_h: [VolatileCell<u32>; 8], // 0x444
     key_w: [VolatileCell<u32>; 8], // 0x464
     sts: VolatileCell<u32>, // 0x484
@@ -24,6 +23,18 @@ struct Registers {
     execute_count_state: VolatileCell<u32>, // 0x4A0
     execute_count_max: VolatileCell<u32>, // 0x4A4
     cert_revoke_ctrl: [VolatileCell<u32>; 3], // 0x4A8
+}
+
+struct U32OrU8(u32);
+
+impl U32OrU8 {
+    pub fn write_u32(&self, word: u32) {
+        unsafe { ::core::intrinsics::volatile_store(&self.0 as *const _ as *const u32 as *mut u32, word) }
+    }
+
+    pub fn write_u8(&self, byte: u8) {
+        unsafe { ::core::intrinsics::volatile_store(&self.0 as *const _ as *const u8 as *mut u8, byte) }
+    }
 }
 
 const KEYMGR0_SHA_REGS: *mut Registers = (KEYMGR0_BASE_ADDRESS + 0x400) as *mut Registers;
@@ -97,11 +108,40 @@ impl DigestEngine for ShaEngine {
             return Err(DigestError::NotConfigured);
         }
 
-        let fifo_u8: &VolatileCell<u8> = unsafe { mem::transmute(&regs.input_fifo) };
-
-        // TODO(yuriks): Feed FIFO word at a time when possible
-        for b in data {
-            fifo_u8.set(*b);
+        // We have a &[u8] but we want to write a word (32 bits) at a time, so
+        // we break it up into 4-byte chunks.
+        for word in data.chunks(4) {
+            if word.len() < 4 {
+                // If there is less than a word left, we have to write one byte
+                // at a time otherwise the SHA engine will include the zero
+                // padding as the length (this relies on the architecture
+                // allowing byte-aligned writes, e.g. the `strb` instruction)
+                for b in word.iter() {
+                    regs.input_fifo.write_u8(*b)
+                }
+            } else {
+                // `word` is a `Chunk<&u8>` of size at most 4, which we want to
+                // convert into a `u32`. This little bit functional code might seem
+                // gnarly, but it's not so bad:
+                //
+                // 1. We `map` over the `Chunk<&u8>` and convert the elements to
+                //    `u32`s to make the types work out. This gives us a
+                //    `Chunk<u32>`.
+                // 2. We `fold` over the `Chunk<u32>`, giving it a tuple with an
+                //    accumulator and the current bit-offset inside the accumulator,
+                //    both initialized to 0.
+                // 3. In each iteration of the `fold`, we add the current byte to
+                //    the accumlator, shifting it by the current offset, and
+                //    increment the offset.
+                // 4. We end up with `(accm, offset <= 32)`, but we only want
+                //    `accm`, so we get field `0` out of the tuple.
+                let d = word.iter()
+                            .map(|b| *b as u32).enumerate()
+                            .fold(0, |accm, (i, byte)| {
+                                accm | (byte << (i * 8))
+                            });
+                regs.input_fifo.write_u32(d);
+            }
         }
 
         Ok(data.len())

--- a/hotel/src/hil/digest.rs
+++ b/hotel/src/hil/digest.rs
@@ -36,15 +36,15 @@ impl From<DigestError> for SyscallError {
 
 pub trait DigestEngine {
     /// Initializes the digest engine for the given mode.
-    fn initialize(&mut self, mode: DigestMode) -> Result<(), DigestError>;
+    fn initialize(&self, mode: DigestMode) -> Result<(), DigestError>;
 
     /// Feeds data into the digest. Returns the number of bytes that were actually consumed from
     /// the input.
-    fn update(&mut self, data: &[u8]) -> Result<usize, DigestError>;
+    fn update(&self, data: &[u8]) -> Result<(), DigestError>;
 
     /// Finalizes the digest, and stores it in the `output` buffer. Returns the number of bytes
     /// stored.
-    fn finalize(&mut self, output: &mut [u8]) -> Result<usize, DigestError>;
+    fn finalize(&self) -> Result<(), DigestError>;
 }
 
 /// Possible errors returned by syscalls. In case of failure, the negative value of the error is
@@ -71,4 +71,8 @@ impl From<SyscallError> for isize {
     fn from(e: SyscallError) -> Self {
         -(e as isize)
     }
+}
+
+pub trait Client {
+    fn done(&self, digest: &[u32]);
 }


### PR DESCRIPTION
Fixes #27 for finalize
- Needed to make `self` references immutable
- Added a `Client` trait for digest
- Split `finalize` into `finalize` and `Client#done` calls

Since `done` is downstream from the client's callback, we can allocate
exactly the size slice we need on the stack and give it to the client
(for a fixed lifetime), letting the client copy/do with it whatever they
want.
